### PR TITLE
Apply missing permissions to topics.

### DIFF
--- a/src/resources/collection.ts
+++ b/src/resources/collection.ts
@@ -59,13 +59,12 @@ class CollectionResource extends Base<CollectionPermission> {
   }
 
   protected permsToActions(...perms: CollectionPermission[]) {
-    return perms.reduce((actions, perm) => {
+    let actions = perms.reduce((actions, perm) => {
       switch (perm) {
         case 'reading':
           return [
             ...actions,
             Action.COLLECTIONDOCUMENTREAD,
-            Action.COLLECTIONLIST,
             Action.COLLECTIONQUERY,
           ];
         case 'writing':
@@ -80,6 +79,12 @@ class CollectionResource extends Base<CollectionPermission> {
           );
       }
     }, []);
+
+    if (actions.length > 0) {
+      actions = [...actions, Action.COLLECTIONLIST]
+    }
+
+    return actions;
   }
 
   /**

--- a/src/resources/queue.test.ts
+++ b/src/resources/queue.test.ts
@@ -14,9 +14,9 @@
 
 import { ResourceServiceClient } from '@nitric/api/proto/resource/v1/resource_grpc_pb';
 import { UnimplementedError } from '../api/errors';
-import { queue } from '.';
+import { Queue } from '../api';
+import { queue, QueueResource } from '.';
 import { ResourceDeclareResponse } from '@nitric/api/proto/resource/v1/resource_pb';
-import { Queue } from '..';
 
 describe('Registering queue resources', () => {
   describe('Given declare returns an error from the resource server', () => {
@@ -86,7 +86,7 @@ describe('Registering queue resources', () => {
 
   describe('Given a topic is already registered', () => {
     const queueName = 'already-exists';
-    let queueResource;
+    let queueResource: QueueResource;
     let existsSpy;
 
     beforeEach(() => {
@@ -127,7 +127,7 @@ describe('Registering queue resources', () => {
 
     describe('When declaring usage', () => {
       it('Should return a topic reference', () => {
-        const ref = queueResource.for('reading');
+        const ref = queueResource.for('receiving');
         expect(ref).toBeInstanceOf(Queue);
       });
     });

--- a/src/resources/queue.ts
+++ b/src/resources/queue.ts
@@ -16,18 +16,19 @@ import {
   ResourceDeclareRequest,
   ResourceType,
   Action,
+  ActionMap,
 } from '@nitric/api/proto/resource/v1/resource_pb';
 import resourceClient from './client';
 import { queues, Queue } from '../api/';
 import { fromGrpcError } from '../api/errors';
 import { ActionsList, make, Resource as Base } from './common';
 
-type QueuePermission = 'sending' | 'receiving';
+export type QueuePermission = 'sending' | 'receiving';
 
 /**
  * Queue resource for async send/receive messaging
  */
-class QueueResource extends Base<QueuePermission> {
+export class QueueResource extends Base<QueuePermission> {
   /**
    * Register this queue as a required resource for the calling function/container
    * @returns a promise that resolves when the registration is complete
@@ -54,7 +55,7 @@ class QueueResource extends Base<QueuePermission> {
   }
 
   protected permsToActions(...perms: QueuePermission[]): ActionsList {
-    let actions = perms.reduce((actions, p) => {
+    let actions: ActionsList = perms.reduce((actions, p) => {
       switch(p) {
         case "sending":
           return [
@@ -66,6 +67,11 @@ class QueueResource extends Base<QueuePermission> {
             ...actions,
             Action.QUEUERECEIVE,
           ];
+        default:
+          throw new Error(
+            `unknown permission ${p}, supported permissions is publishing.}
+            )}`
+          );
       }
     }, []);
 

--- a/src/resources/queue.ts
+++ b/src/resources/queue.ts
@@ -54,7 +54,7 @@ class QueueResource extends Base<QueuePermission> {
   }
 
   protected permsToActions(...perms: QueuePermission[]): ActionsList {
-    return perms.reduce((actions, p) => {
+    let actions = perms.reduce((actions, p) => {
       switch(p) {
         case "sending":
           return [
@@ -68,6 +68,12 @@ class QueueResource extends Base<QueuePermission> {
           ];
       }
     }, []);
+
+    if (actions.length > 0) {
+      actions = [...actions, Action.QUEUELIST, Action.QUEUEDETAIL]
+    }
+
+    return actions;
   }
 
   /**

--- a/src/resources/topic.ts
+++ b/src/resources/topic.ts
@@ -84,7 +84,7 @@ class TopicResource extends Base<TopicPermission> {
     return perms.reduce((actions, p) => {
       switch (p) {
         case 'publishing':
-          return [...actions, Action.TOPICEVENTPUBLISH];
+          return [...actions, Action.TOPICEVENTPUBLISH, Action.TOPICLIST, Action.TOPICDETAIL];
         default:
           throw new Error(
             `unknown permission ${p}, supported permissions is publishing.}


### PR DESCRIPTION
Additional permissions required to find topics by their nitric name, these include listing and reading tags.