### PR TITLE
Add payload retrieval convenience methods to AbstractRequest

### DIFF
--- a/examples/faas/events.ts
+++ b/examples/faas/events.ts
@@ -20,7 +20,7 @@ export const events = async () => {
 	// [START snippet]
 	await faas
 	.event(async (ctx) => {
-		console.log("received event: ", ctx.req.payload);
+		console.log("received event: ", ctx.req.json());
 
 		// mark the event as successfully handled
 		ctx.res.success = true;

--- a/src/faas/v0/context.ts
+++ b/src/faas/v0/context.ts
@@ -85,6 +85,20 @@ export abstract class AbstractRequest {
   protected constructor(data: string | Uint8Array) {
     this.data = data;
   }
+
+  text(): string {
+    const stringPayload = typeof this.data === 'string' 
+      ? this.data 
+      : new TextDecoder('utf-8').decode(this.data);
+
+    // attempt to deserialize as a JSON object
+    return stringPayload;
+  }
+
+  json(): Record<string, any> {
+    // attempt to deserialize as a JSON object
+    return JSON.parse(this.text());
+  }
 }
 
 interface EventResponse {
@@ -154,10 +168,6 @@ export class EventRequest extends AbstractRequest {
   constructor(data: string | Uint8Array, topic: string) {
     super(data);
     this.topic = topic;
-  }
-
-  get payload(): string | Uint8Array {
-    return this.data;
   }
 }
 

--- a/src/faas/v0/context.ts
+++ b/src/faas/v0/context.ts
@@ -91,7 +91,6 @@ export abstract class AbstractRequest {
       ? this.data 
       : new TextDecoder('utf-8').decode(this.data);
 
-    // attempt to deserialize as a JSON object
     return stringPayload;
   }
 


### PR DESCRIPTION
Adds `json()` and `text()` methods to Abstract request meaning that any request object can have its payload retrieved simply by calling either of these methods.

e.g. 
```javascript
import { topic } from '@nitric/sdk';

const t = topic('test');

t.subscribe(ctx => {
  // print json body (will throw if data is not json).
  console.log(ctx.req.json())
}) 

```