### PR TITLE
Move generic onto collection resource

### DIFF
--- a/src/resources/collection.ts
+++ b/src/resources/collection.ts
@@ -31,7 +31,7 @@ const everything: CollectionPermission[] = ['reading', 'writing', 'deleting'];
 /**
  * A document collection resources, such as a collection/table in a document database.
  */
-class CollectionResource extends Base<CollectionPermission> {
+class CollectionResource<T extends DocumentStructure> extends Base<CollectionPermission> {
   /**
    * Register this collection as a required resource for the calling function/container
    * @returns a promise that resolves when the registration is complete
@@ -95,7 +95,7 @@ class CollectionResource extends Base<CollectionPermission> {
    * @param perms the required permission set
    * @returns a usable collection reference
    */
-  public for<T extends DocumentStructure>(...perms: CollectionPermission[]) {
+  public for(...perms: CollectionPermission[]) {
     this.registerPolicy(...perms);
 
     return documents().collection<T>(this.name);


### PR DESCRIPTION
Move generic onto root resource off of for, so typing can be shared independent of permissions.