### PR TITLE
chore: clean up old todos that aren't needed anymore

### DIFF
--- a/src/faas/v0/context.ts
+++ b/src/faas/v0/context.ts
@@ -181,7 +181,7 @@ export class HttpContext extends TriggerContext<HttpRequest, HttpResponse> {
 
     const headers = ((http
       .getHeadersMap()
-      // XXX: getEntryList claims to return [string, faas.HeaderValue][], but really returns [string, string[][]][]
+      // getEntryList claims to return [string, faas.HeaderValue][], but really returns [string, string[][]][]
       // we force the type to match the real return type.
       .getEntryList() as unknown) as [string, string[][]][]).reduce(
       (acc, [key, [val]]) => ({
@@ -193,7 +193,7 @@ export class HttpContext extends TriggerContext<HttpRequest, HttpResponse> {
 
     const query = ((http
       .getQueryParamsMap()
-      // XXX: getEntryList claims to return [string, faas.HeaderValue][], but really returns [string, string[][]][]
+      // getEntryList claims to return [string, faas.HeaderValue][], but really returns [string, string[][]][]
       // we force the type to match the real return type.
       .getEntryList() as unknown) as [string, string[][]][]).reduce(
       (acc, [key, [val]]) => ({
@@ -205,7 +205,7 @@ export class HttpContext extends TriggerContext<HttpRequest, HttpResponse> {
 
     const params = http
       .getPathParamsMap()
-      // XXX: getEntryList claims to return [string, faas.HeaderValue][], but really returns [string, string[][]][]
+      // getEntryList claims to return [string, faas.HeaderValue][], but really returns [string, string[][]][]
       // we force the type to match the real return type.
       .getEntryList()
       .reduce(

--- a/src/faas/v0/start.test.ts
+++ b/src/faas/v0/start.test.ts
@@ -63,7 +63,6 @@ describe('faas.start', () => {
     });
 
     it('The first sent message should be an InitRequest', () => {
-      // TODO: Add test
       expect(mockStream.receivedMessages[0].hasInitRequest()).toBe(true);
     });
 

--- a/src/resources/topic.ts
+++ b/src/resources/topic.ts
@@ -80,11 +80,15 @@ class TopicResource extends Base<TopicPermission> {
   }
 
   protected permsToActions(...perms: TopicPermission[]): ActionsList {
-    // TODO
     return perms.reduce((actions, p) => {
       switch (p) {
         case 'publishing':
-          return [...actions, Action.TOPICEVENTPUBLISH, Action.TOPICLIST, Action.TOPICDETAIL];
+          return [
+            ...actions,
+            Action.TOPICEVENTPUBLISH,
+            Action.TOPICLIST,
+            Action.TOPICDETAIL,
+          ];
         default:
           throw new Error(
             `unknown permission ${p}, supported permissions is publishing.}
@@ -100,9 +104,6 @@ class TopicResource extends Base<TopicPermission> {
    * @returns Promise which resolves when the handler server terminates
    */
   subscribe(...mw: EventMiddleware[]): Promise<void> {
-    // TODO: Check if publish policy has already been registered and error.
-    // TODO: register subscription policy
-
     const sub = new Subscription(this.name, ...mw);
     return sub['start']();
   }
@@ -115,10 +116,7 @@ class TopicResource extends Base<TopicPermission> {
    * @param perms the required permission set
    * @returns a usable topic reference
    */
-
   public for<T>(...perms: TopicPermission[]) {
-    // TODO: check if subscriber has been registered and error if so.
-    // TODO: register required policy resource.
     this.registerPolicy(...perms);
     return events().topic(this.name);
   }


### PR DESCRIPTION
The note about throwing an error when a function subscribes to a topic that it also publishes too should probably be a feature on the server, instead of the clients. I'll create an issue and we can review options for implementing it.