### PR TITLE
feat(storage): provide getUploadUrl and getDownloadUrl methods on files

### DIFF
--- a/src/api/storage/v0/storage.test.ts
+++ b/src/api/storage/v0/storage.test.ts
@@ -228,14 +228,14 @@ describe('Storage Client Tests', () => {
       jest.resetAllMocks();
     });
 
-    test('Then StorageClient.delete should reject', async () => {
+    test('Then file.signUrl should reject', async () => {
       const client = new Storage();
       await expect(client.bucket('test').file('test').signUrl(FileMode.Read)).rejects.toEqual(
         new UnimplementedError("UNIMPLEMENTED")
       );
     });
 
-    test('The Grpc client for Storage.delete should have been called exactly once', () => {
+    test('The Grpc client for file.signUrl should have been called exactly once', () => {
       expect(signUrlMock).toBeCalledTimes(1);
     });
   });
@@ -244,14 +244,13 @@ describe('Storage Client Tests', () => {
     const MOCK_REPLY = new StoragePreSignUrlResponse();
     MOCK_REPLY.setUrl("testingUrl");
 
-    let preSignUrlMock;
+    let preSignUrlMock: jest.SpyInstance;
 
     beforeAll(() => {
       preSignUrlMock = jest
         .spyOn(GrpcStorageClient.prototype, 'preSignUrl')
         .mockImplementation((_, callback: any) => {
           callback(null, MOCK_REPLY);
-
           return null as any;
         });
     });
@@ -259,23 +258,87 @@ describe('Storage Client Tests', () => {
     afterAll(() => {
       jest.resetAllMocks();
     });
+    
 
-    test('Then StorageClient.delete should delete the bytes from the bucket', async () => {
-      const client = new Storage().bucket('test_bucket').file('test/item');
-      await expect(client.signUrl(FileMode.Read)).resolves.toEqual("testingUrl");
+    describe('When calling file.signUrl', () => {
+      let signUrl;
+
+      beforeAll(async () => {
+        preSignUrlMock.mockClear();
+        const client = new Storage().bucket('test_bucket').file('test/item');
+        signUrl = await client.signUrl(FileMode.Read)
+      })
+
+      test('Then file.signUrl should delete the bytes from the bucket', () => {
+        expect(signUrl).toEqual("testingUrl");
+      });
+  
+      test('The Grpc client for file.signUrl should have been called exactly once', () => {
+        expect(preSignUrlMock).toBeCalledTimes(1);
+      });
+  
+      test('The Grpc client for file.signUrl should have been called with provided options', () => {
+        const MOCK_REQUEST = new StoragePreSignUrlRequest();
+        MOCK_REQUEST.setBucketName("test_bucket");
+        MOCK_REQUEST.setKey("test/item");
+        MOCK_REQUEST.setOperation(FileMode.Read);
+        MOCK_REQUEST.setExpiry(600);
+        expect(preSignUrlMock).toBeCalledWith(MOCK_REQUEST, expect.anything());
+      });
     });
 
-    test('The Grpc client for Storage.delete should have been called exactly once', () => {
-      expect(preSignUrlMock).toBeCalledTimes(1);
+    describe('When calling file.getUploadUrl', () => {
+      let signUrl;
+
+      beforeAll(async () => {
+        preSignUrlMock.mockClear();
+        const client = new Storage().bucket('test_bucket').file('test/item');
+        signUrl = await client.getUploadUrl()
+      })
+
+      test('Then file.signUrl should delete the bytes from the bucket', () => {
+        expect(signUrl).toEqual("testingUrl");
+      });
+  
+      test('The Grpc client for file.signUrl should have been called exactly once', () => {
+        expect(preSignUrlMock).toBeCalledTimes(1);
+      });
+  
+      test('The Grpc client for file.signUrl should have been called with provided options', () => {
+        const MOCK_REQUEST = new StoragePreSignUrlRequest();
+        MOCK_REQUEST.setBucketName("test_bucket");
+        MOCK_REQUEST.setKey("test/item");
+        MOCK_REQUEST.setOperation(FileMode.Write);
+        MOCK_REQUEST.setExpiry(600);
+        expect(preSignUrlMock).toBeCalledWith(MOCK_REQUEST, expect.anything());
+      });
     });
 
-    test('The Grpc client for Storage.delete should have been called with provided options', () => {
-      const MOCK_REQUEST = new StoragePreSignUrlRequest();
-      MOCK_REQUEST.setBucketName("test_bucket");
-      MOCK_REQUEST.setKey("test/item");
-      MOCK_REQUEST.setOperation(FileMode.Read);
-      MOCK_REQUEST.setExpiry(600);
-      expect(preSignUrlMock).toBeCalledWith(MOCK_REQUEST, expect.anything());
+    describe('When calling file.getUploadUrl', () => {
+      let signUrl;
+
+      beforeAll(async () => {
+        preSignUrlMock.mockClear();
+        const client = new Storage().bucket('test_bucket').file('test/item');
+        signUrl = await client.getDownloadUrl()
+      })
+
+      test('Then file.signUrl should delete the bytes from the bucket', () => {
+        expect(signUrl).toEqual("testingUrl");
+      });
+  
+      test('The Grpc client for file.signUrl should have been called exactly once', () => {
+        expect(preSignUrlMock).toBeCalledTimes(1);
+      });
+  
+      test('The Grpc client for file.signUrl should have been called with provided options', () => {
+        const MOCK_REQUEST = new StoragePreSignUrlRequest();
+        MOCK_REQUEST.setBucketName("test_bucket");
+        MOCK_REQUEST.setKey("test/item");
+        MOCK_REQUEST.setOperation(FileMode.Read);
+        MOCK_REQUEST.setExpiry(600);
+        expect(preSignUrlMock).toBeCalledWith(MOCK_REQUEST, expect.anything());
+      });
     });
   });
 });

--- a/src/api/storage/v0/storage.ts
+++ b/src/api/storage/v0/storage.ts
@@ -105,7 +105,28 @@ export class File {
   }
 
   /**
+   * Get a pre-signed download URL for the file
+   * @param opts the option passed to the signUrl function.
+   * @returns a download URL string
+   */
+  public getDownloadUrl(opts?: SignUrlOptions): Promise<string> {
+    return this.signUrl(FileMode.Read, opts)
+  }
+
+  /**
+   * Get a pre-signed upload URL for the file.
+   * @param opts the option passed to the signUrl function.
+   * @returns a upload URL string
+   */
+  public getUploadUrl(opts?: SignUrlOptions): Promise<string> {
+    return this.signUrl(FileMode.Write, opts)
+  }
+
+  /**
    * Create a presigned url for reading or writing for the given file reference
+   * @param mode the mode the url will access the file with. E.g. reading or writing.
+   * @param opts.expiry how long the URL should be valid for in seconds.
+   * @deprecated for simplicity we suggest using getUploadUrl or getDownloadUrl
    */
   public async signUrl(
     mode: FileMode,


### PR DESCRIPTION
Not 100% sure about deprecating the 'signUrl' method on files, but I feel it adds clutter to the SDK for a method that's unlikely to be used now.

Examples:

**Before**

```javascript
import { bucket, FileMode } from '@nitric/sdk';

const assets = bucket('assets').for('reading', 'writing');

const logo = assets.file('images/logo.png');

const logoUrl = await logo.signUrl(FileMode.Read);
```

**Now**

```javascript
import { bucket } from '@nitric/sdk';

const assets = bucket('assets').for('reading', 'writing');

const logo = assets.file('images/logo.png');

const logoUrl = await logo.getDownloadUrl();
```