### PR TITLE
Storage: Add ability to list files in a bucket.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "@grpc/grpc-js": "^1.5.9",
-    "@nitric/api": "0.16.0-rc.14",
+    "@nitric/api": "0.16.0",
     "google-protobuf": "3.14.0",
     "tslib": "^2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "@grpc/grpc-js": "^1.5.9",
-    "@nitric/api": "0.15.0",
+    "@nitric/api": "0.16.0-rc.14",
     "google-protobuf": "3.14.0",
     "tslib": "^2.1.0"
   },

--- a/src/api/storage/v0/storage.test.ts
+++ b/src/api/storage/v0/storage.test.ts
@@ -364,14 +364,14 @@ describe('Storage Client Tests', () => {
       jest.resetAllMocks();
     });
 
-    test('Then StorageClient.delete should reject', async () => {
+    test('Then StorageClient.listFiles should reject', async () => {
       const client = new Storage();
       await expect(client.bucket('test').files()).rejects.toEqual(
         new UnimplementedError("UNIMPLEMENTED")
       );
     });
 
-    test('The Grpc client for Storage.delete should have been called exactly once', () => {
+    test('The Grpc client for Storage.listFiles should have been called exactly once', () => {
       expect(listFilesMock).toBeCalledTimes(1);
     });
   });
@@ -408,7 +408,7 @@ describe('Storage Client Tests', () => {
       expect(files[0].name).toBe('test/test.txt')
     });
 
-    test('The Grpc client for Storage.delete should have been called exactly once', () => {
+    test('The Grpc client for Storage.listFiles should have been called exactly once', () => {
       expect(listFilesMock).toBeCalledTimes(1);
     });
   });

--- a/src/api/storage/v0/storage.ts
+++ b/src/api/storage/v0/storage.ts
@@ -64,6 +64,10 @@ export class Bucket {
     this.name = name;
   }
 
+  /**
+   * Retrieve a list of files on the bucket
+   * @returns An array of file references
+   */
   public async files(): Promise<File[]> {
     const request = new StorageListFilesRequest();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -531,10 +531,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@nitric/api@0.16.0-rc.14":
-  version "0.16.0-rc.14"
-  resolved "https://registry.yarnpkg.com/@nitric/api/-/api-0.16.0-rc.14.tgz#7a33a49ad295982a638787351cb7e634c18c79d0"
-  integrity sha512-EH3PUQIOD9/Qx5vZYRF4b8vioEACY5pPtzKgk3aQYjZJrrDhWcN4AcUV0/9RhDeWi9mPXqY1/ZklQGg7thJGXg==
+"@nitric/api@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@nitric/api/-/api-0.16.0.tgz#233a1aa3cb4ef29188b5336c0e70d067e027cb26"
+  integrity sha512-dXJfPlAe/G35nSVn4IIvjB0TqWYJPyYNOqu1TdjV14vy++L7ALkabVJtKULQQ94+71okvfmO4kMHQeKsYYS/Mw==
   dependencies:
     google-protobuf "3.14.0"
     tslib "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -531,10 +531,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@nitric/api@0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@nitric/api/-/api-0.15.0.tgz#4e8825dd0fda21437b477e6c81ab2bb1f15a22e6"
-  integrity sha512-xxldlWIAZHhkrfHsueEcZ9zaoSLTSAtHlrrZaodF5bKIJigbXkI3GLhSLm1hOcFGerguUx1y8l+Pc/slPI+s6g==
+"@nitric/api@0.16.0-rc.14":
+  version "0.16.0-rc.14"
+  resolved "https://registry.yarnpkg.com/@nitric/api/-/api-0.16.0-rc.14.tgz#7a33a49ad295982a638787351cb7e634c18c79d0"
+  integrity sha512-EH3PUQIOD9/Qx5vZYRF4b8vioEACY5pPtzKgk3aQYjZJrrDhWcN4AcUV0/9RhDeWi9mPXqY1/ZklQGg7thJGXg==
   dependencies:
     google-protobuf "3.14.0"
     tslib "^2.1.0"


### PR DESCRIPTION
Add files listing to buckets, a list of files can be retrieved by using:

``` typescript
import { bucket } from '@nitric/sdk';

const myBucket = bucket('my-bucket');

// Get list of files refrerences
const files = await myBucket.files();

// delete all files on the bucket
// this demonstrates that file references are returned.
await Promise.all(files.map(f => f.delete()));
```