### PR TITLE
fix: Don't overwrite blobRequest event fields

### DIFF
--- a/src/api/storage/v1/storage.ts
+++ b/src/api/storage/v1/storage.ts
@@ -120,7 +120,7 @@ export class Bucket {
       notificationPrefixFilter,
       ...middleware
     );
-    return notification['start']();
+    return notification['start'](this);
   }
 }
 

--- a/src/resources/bucket.ts
+++ b/src/resources/bucket.ts
@@ -33,7 +33,6 @@ import {
   ClientMessage,
   RegistrationRequest,
   ServerMessage,
-  BlobEvent,
   BlobEventResponse,
 } from '@nitric/proto/storage/v1/storage_pb';
 import { StorageListenerClient } from '@nitric/proto/storage/v1/storage_grpc_pb';

--- a/src/resources/bucket.ts
+++ b/src/resources/bucket.ts
@@ -138,12 +138,6 @@ export class BucketNotification {
           responseMessage.setId(message.getId());
 
           try {
-            blobEventRequest.setBucketName(this.options.bucket);
-            const blobEvent = new BlobEvent();
-            blobEvent.setKey(this.options.notificationPrefixFilter);
-            blobEvent.setType(this.options.notificationType);
-            blobEventRequest.setBlobEvent(blobEvent);
-
             if (bucket) {
               const ctx = BlobEventContext.fromRequest(
                 blobEventRequest,


### PR DESCRIPTION
Also fix missing bucket reference for bucket references with permissions when adding notifications.
