### PR TITLE
make server type more generic to allow for more frameworks

### DIFF
--- a/src/resources/http.ts
+++ b/src/resources/http.ts
@@ -17,10 +17,11 @@ import { HttpClient } from '@nitric/proto/http/v1/http_grpc_pb';
 import { SERVICE_BIND } from '../constants';
 import * as grpc from '@grpc/grpc-js';
 import { ClientMessage, HttpProxyRequest } from '@nitric/proto/http/v1/http_pb';
-import { Server } from 'http';
-import { Http2SecureServer, Http2Server } from 'http2';
 
-type ServerType = Server | Http2Server | Http2SecureServer;
+interface ServerType {
+  on: (eventType: string, callback: () => void, options?: any) => void;
+  close?: () => void;
+}
 
 type ListenerFunction =
   | ((port: number, callback?: () => void) => ServerType | Promise<ServerType>)

--- a/src/resources/http.ts
+++ b/src/resources/http.ts
@@ -19,7 +19,11 @@ import * as grpc from '@grpc/grpc-js';
 import { ClientMessage, HttpProxyRequest } from '@nitric/proto/http/v1/http_pb';
 
 interface ServerType {
-  on: (eventType: string, callback: () => void, options?: any) => void;
+  on: (
+    eventType: 'close',
+    callback: () => void,
+    options?: Record<string, any>
+  ) => void;
   close?: () => void;
 }
 


### PR DESCRIPTION
`yarn add https://github.com/HomelessDinosaur/node-sdk.git\#test-oak`

Tested with:
- Hono
- Express
- Fastify
- Koa
- Nestjs
- Oak